### PR TITLE
Throw an error on #off if callback not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,9 +81,11 @@ proto.off = function(name, cb) {
   if (!cb) { return delete this._cbs[name]; }
 
   var cbs = this._cbs[name] || [];
+  var l = cbs.length;
   var i;
 
   while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  if (l === cbs.length) throw new Error('Unable to remove event listener');
   return this;
 };
 

--- a/index.js
+++ b/index.js
@@ -81,11 +81,10 @@ proto.off = function(name, cb) {
   if (!cb) { return delete this._cbs[name]; }
 
   var cbs = this._cbs[name] || [];
-  var l = cbs.length;
   var i;
 
+  if (!~cbs.indexOf(cb)) throw new Error('Unable to remove event listener for event '+name);
   while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
-  if (l === cbs.length) throw new Error('Unable to remove event listener');
   return this;
 };
 

--- a/test/test.event.off.js
+++ b/test/test.event.off.js
@@ -64,7 +64,7 @@ suite('Events#off()', function(){
     var caught = false;
 
     emitter
-      .on('eventname', callback.bind('whatever');
+      .on('eventname', callback.bind('whatever'));
 
     try {
       emitter

--- a/test/test.event.off.js
+++ b/test/test.event.off.js
@@ -57,4 +57,21 @@ suite('Events#off()', function(){
     assert(!callback.called);
     assert(!callback2.called);
   });
+
+  test("Should throw an error if you try to remove a callback that doesn't exist", function() {
+    var emitter = new Events();
+    var callback = sinon.spy();
+    var caught = false;
+
+    emitter
+      .on('eventname', callback.bind('whatever');
+
+    try {
+      emitter
+        .off('eventname', callback);
+    } catch(e) {
+      caught = true;
+    }
+    assert(caught);
+  });
 });


### PR DESCRIPTION
Wonder if you'd consider this...  would be really helpful to avoid the really common mistake of adding event listeners with bound functions and then trying to remove them with via the original unbound version..
